### PR TITLE
Add daily build to check for vulnerable dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,3 +52,17 @@ workflows:
       - vulnerability_check:
           requires:
             - checkout_and_bundle
+
+  security-audit:
+    triggers:
+      - schedule:
+          # 11:50 am UTC: 6:50 am EST / 7:50 am EDT
+          cron: "50 11 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - checkout_and_bundle
+      - vulnerability_check:
+          requires:
+            - checkout_and_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,54 @@
 # Ruby CircleCI 2.0 configuration file
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 version: 2
+
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: circleci/ruby:2.5.0
+
+references:
+  attach_code_workspace: &attach_code_workspace
+    attach_workspace:
+      at: ~/repo
+
+  restore_bundle_dependencies: &restore_bundle_dependencies
+    run:
+      name: Restore bundle dependencies from workspace
+      command: bundle --path vendor/bundle
+
 jobs:
-  build:
-    docker:
-       - image: circleci/ruby:2.5.0
-    working_directory: ~/repo
+  checkout_and_bundle:
+    <<: *defaults
     steps:
       - checkout
       - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
-      - run: bundle exec bundle-audit update && bundle exec bundle-audit check
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  rspec:
+    <<: *defaults
+    steps:
+      - *attach_code_workspace
+      - *restore_bundle_dependencies
       - run: bundle exec rspec
+
+  vulnerability_check:
+    <<: *defaults
+    steps:
+      - *attach_code_workspace
+      - *restore_bundle_dependencies
+      - run: bundle exec bundle-audit update && bundle exec bundle-audit check
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - checkout_and_bundle
+      - rspec:
+          requires:
+            - checkout_and_bundle
+      - vulnerability_check:
+          requires:
+            - checkout_and_bundle


### PR DESCRIPTION
This follows the same pattern I've been using in a number of other repos.

I'm aiming to eventually get all of the repos that have a bundle-audit check in their build to also have a scheduled build that runs daily. That way we'll find out about newly published vulnerable dependencies within about a day, rather than when someone next makes a change in the particular repo and the builds fail.

As usual, the time is fixed but chosen randomly within that hour, with the aim that we don't flood the queue but that they've all finished by the start of the working day in Toronto.

Since I've rearranged the build to use a workflow, I'll need to tweak the repo settings under Settings > Branches > Protected Branches to set the new required builds for master. I'll do that with Lee's assistance after this is approved, so it can merge promptly after I change the settings.